### PR TITLE
texture -> diffuse

### DIFF
--- a/addons/io_scene_gltf2/blender/exp/gltf2_blender_gather_materials.py
+++ b/addons/io_scene_gltf2/blender/exp/gltf2_blender_gather_materials.py
@@ -157,7 +157,7 @@ def __gather_extensions(blender_material, export_settings):
             extensions["KHR_materials_unlit"] = Extension("KHR_materials_unlit", {}, False)
 
     if blender_material.get("useVideoTextureExtension", False) == "True":
-        image_name = blender_material.get("videoTextureExtension_ImageName")
+        image_name = blender_material.get("videoTextureExtension_DiffuseImageName")
         if image_name is not None:
             image = bpy.data.images[image_name]
             if image is not None and image.source == "MOVIE":
@@ -185,7 +185,7 @@ def __gather_extensions(blender_material, export_settings):
                         source=source
                     )
 
-                    extension = dict(texture=texture)
+                    extension = dict(diffuse=texture)
                     extensions["SVRF_video_texture"] = Extension("SVRF_video_texture", extension, False)
 
     # TODO specular glossiness extension


### PR DESCRIPTION
Rename field "texture" in the "SVRF_video_texture" extension to "diffuse" to better indicate which texture is being changed.

This also means that the custom property that tracks the diffuse image name is now `videoTextureExtension_DiffuseImageName`

@calvertcreates 